### PR TITLE
ref: Conversion script path option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ To create jpg and png files, you need to have imagemagick, exiftool and `inkscap
 
 `./conversion-script.sh <optional file path>`
 
-Output is written to `pictures-png` and `pictures-jpg` respectively.
+Output is written to `pictures-png` and `pictures-jpg` respectively.  
+Giving a folder as file path does currently not work.
 
 ## Symlinks
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Any such exception is marked with a `cc:License` or `cc:license` tag within the 
 
 ## Creating JPG and PNG
 
-To create jpg and png files, you need to have imagemagick and `inkscape` installed. Rune
+To create jpg and png files, you need to have imagemagick, exiftool and `inkscape` installed. Rune
 
 `./conversion-script.sh`
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Any such exception is marked with a `cc:License` or `cc:license` tag within the 
 
 ## Creating JPG and PNG
 
-To create jpg and png files, you need to have imagemagick, exiftool and `inkscape` installed. Rune
+To create jpg and png files, you need to have imagemagick, exiftool and `inkscape` installed. Run
 
-`./conversion-script.sh`
+`./conversion-script.sh <optional file path>`
 
 Output is written to `pictures-png` and `pictures-jpg` respectively.
 

--- a/conversion-script.sh
+++ b/conversion-script.sh
@@ -19,7 +19,7 @@ convert_file() {
 }
 
 # Take optional file, to only convert one file (or another path)
-FILE_PATH=${1:-STANDARD_PATH}
+FILE_PATH=${1:-$STANDARD_PATH}
 
 # convert svg to jpg and png if needed
 CREATE_JPG=${CREATE_JPG:-true}

--- a/conversion-script.sh
+++ b/conversion-script.sh
@@ -3,7 +3,13 @@
 set -eEu
 set -o pipefail  # avoid masking failures in pipes
 shopt -s nullglob  # do not run loops if the glob has not found anything
+
+# The standard SVG path
 STANDARD_PATH="pictures-svg/*.svg"
+# Take optional file, to only convert one file (or another path)
+FILE_PATH=${1:-$STANDARD_PATH}
+# convert svg to jpg and png if needed
+CREATE_JPG=${CREATE_JPG:-true}
 
 convert_file() {
     local file_path="$1"
@@ -17,12 +23,6 @@ convert_file() {
     # transfer license and author tags to jpg
     exiftool -overwrite_original -tagsfromfile "pictures-png/$normalized.png" "pictures-jpg/$normalized.jpg"
 }
-
-# Take optional file, to only convert one file (or another path)
-FILE_PATH=${1:-$STANDARD_PATH}
-
-# convert svg to jpg and png if needed
-CREATE_JPG=${CREATE_JPG:-true}
 
 if [[ "${CREATE_JPG}" == "true" ]]; then
     echo "creating jpg folders"

--- a/conversion-script.sh
+++ b/conversion-script.sh
@@ -3,6 +3,23 @@
 set -eEu
 set -o pipefail  # avoid masking failures in pipes
 shopt -s nullglob  # do not run loops if the glob has not found anything
+STANDARD_PATH="pictures-svg/*.svg"
+
+convert_file() {
+    local file_path="$1"
+    local normalized="$2"
+
+    inkscape "${file_path}" --batch-process --export-type=png --export-filename="pictures-png/$normalized.png" --export-background-opacity=0
+    # as not all SVG are updated to have no borders, trim unnecessary white borders from png
+    mogrify -trim "pictures-png/$normalized.png"
+    # even though mogrify trims the png, we need to trim again for the jpg
+    convert "pictures-png/$normalized.png" -resize 65536@\> -background white -flatten -alpha off -trim "pictures-jpg/$normalized.jpg"
+    # transfer license and author tags to jpg
+    exiftool -overwrite_original -tagsfromfile "pictures-png/$normalized.png" "pictures-jpg/$normalized.jpg"
+}
+
+# Take optional file, to only convert one file (or another path)
+FILE_PATH=${1:-STANDARD_PATH}
 
 # convert svg to jpg and png if needed
 CREATE_JPG=${CREATE_JPG:-true}
@@ -13,10 +30,13 @@ if [[ "${CREATE_JPG}" == "true" ]]; then
     mkdir -p pictures-png
 fi
 
-for file in pictures-svg/*.svg; do
+for file in $FILE_PATH; do
     normalized=${file##pictures-svg/}
     normalized=${normalized%.svg}
     normalized="$(echo "$normalized" | sed -e 's/fritzbox/fritz-box/ig' -e 's/[^a-z0-9\.\-]/-/ig')"
+    if [[ "${FILE_PATH}" == "${STANDARD_PATH}" ]]; then
+        file=pictures-svg/$normalized.svg
+    fi
 
     if [ "$file" == "pictures-svg/no_picture_available.svg" ]; then
         normalized="no_picture_available"
@@ -30,20 +50,14 @@ for file in pictures-svg/*.svg; do
         continue
     fi
 
-    if [[ -L "pictures-svg/$normalized.svg" ]]; then
-        link_filepath=$(readlink -f "pictures-svg/$normalized.svg")
+    if [[ -L "${file}" ]]; then
+        link_filepath=$(readlink -f "${file}")
         link_file=$(basename "$link_filepath")
         link_name="${link_file%.svg}"
         echo "Symlinking $normalized to $link_name. Skipping conversion."
         ln -sf "$link_name.png" "pictures-png/$normalized.png"
         ln -sf "$link_name.jpg" "pictures-jpg/$normalized.jpg"
     else
-        inkscape "pictures-svg/$normalized.svg" --batch-process --export-type=png --export-filename="pictures-png/$normalized.png" --export-background-opacity=0
-        # as not all SVG are updated to have no borders, trim unnecessary white borders from png
-        mogrify -trim "pictures-png/$normalized.png"
-        # even though mogrify trims the png, we need to trim again for the jpg
-        convert "pictures-png/$normalized.png" -resize 65536@\> -background white -flatten -alpha off -trim "pictures-jpg/$normalized.jpg"
-        # transfer license and author tags to jpg
-        exiftool -overwrite_original -tagsfromfile "pictures-png/$normalized.png" "pictures-jpg/$normalized.jpg"
+        convert_file "${file}" "${normalized}"
     fi
 done;


### PR DESCRIPTION
This PR adds an optional parameter to the conversion script, making it possible to only convert one picture (or another path), speeding up the process when you only need one. I outsourced the conversion into a function as I think it looks clearer that way.
I furthermore added exiftool to the dependencies.
The original plan was to also make the conversion concurrent, but I failed at doing so. Inkscape seems to not be a fan of more than one instance.